### PR TITLE
docs: add baseline data schema and seed JSON datasets

### DIFF
--- a/docs/data/components-status.json
+++ b/docs/data/components-status.json
@@ -1,0 +1,20 @@
+{
+  "components": [
+    {
+      "id": "core-engine",
+      "status": "in-progress",
+      "owner": "platform-team",
+      "lastUpdated": "2026-02-15",
+      "milestone": "m1",
+      "priority": "high"
+    },
+    {
+      "id": "event-system",
+      "status": "planned",
+      "owner": "platform-team",
+      "lastUpdated": "2026-02-15",
+      "milestone": "m2",
+      "priority": "medium"
+    }
+  ]
+}

--- a/docs/data/roadmap.json
+++ b/docs/data/roadmap.json
@@ -1,0 +1,20 @@
+{
+  "items": [
+    {
+      "id": "schema-baseline",
+      "status": "done",
+      "owner": "docs-team",
+      "lastUpdated": "2026-02-15",
+      "milestone": "2026-q1",
+      "priority": "high"
+    },
+    {
+      "id": "consumer-adoption",
+      "status": "planned",
+      "owner": "product-team",
+      "lastUpdated": "2026-02-15",
+      "milestone": "2026-q2",
+      "priority": "medium"
+    }
+  ]
+}

--- a/docs/data/schema.md
+++ b/docs/data/schema.md
@@ -1,0 +1,75 @@
+# Data Schema
+
+이 문서는 `docs/data/` 하위 JSON 파일에서 공통으로 사용하는 필드명 규칙을 고정합니다.
+
+## 고정 필드명 규칙
+
+아래 필드명은 스키마 기준 필드이며, 새로운 데이터 추가 시 동일한 이름을 사용해야 합니다.
+
+- `id`: 항목 고유 식별자 (`kebab-case` 문자열)
+- `status`: 현재 상태 (`planned` | `in-progress` | `done` | `blocked`)
+- `owner`: 담당자 또는 담당 팀
+- `lastUpdated`: 마지막 갱신 시각 (`YYYY-MM-DD`)
+- `milestone`: 마일스톤 식별자 또는 이름
+- `priority`: 우선순위 (`low` | `medium` | `high` | `critical`)
+
+## 파일별 구조
+
+### `components-status.json`
+
+```json
+{
+  "components": [
+    {
+      "id": "component-id",
+      "status": "in-progress",
+      "owner": "team-name",
+      "lastUpdated": "2026-02-15",
+      "milestone": "m1",
+      "priority": "high"
+    }
+  ]
+}
+```
+
+### `roadmap.json`
+
+```json
+{
+  "items": [
+    {
+      "id": "roadmap-item-id",
+      "status": "planned",
+      "owner": "team-name",
+      "lastUpdated": "2026-02-15",
+      "milestone": "2026-q1",
+      "priority": "medium"
+    }
+  ]
+}
+```
+
+### `usage-guides.json`
+
+```json
+{
+  "guides": [
+    {
+      "id": "guide-id",
+      "status": "done",
+      "owner": "docs-team",
+      "lastUpdated": "2026-02-15",
+      "milestone": "docs-v1",
+      "priority": "low"
+    }
+  ]
+}
+```
+
+## 리뷰 포인트
+
+본 PR의 리뷰 포인트는 **데이터 스키마 적합성**으로 한정합니다.
+
+## 머지 후 원칙
+
+머지 이후 생성되는 다른 PR은 이 문서의 스키마(필드명 규칙)를 기준으로만 참조합니다.

--- a/docs/data/usage-guides.json
+++ b/docs/data/usage-guides.json
@@ -1,0 +1,20 @@
+{
+  "guides": [
+    {
+      "id": "getting-started",
+      "status": "done",
+      "owner": "docs-team",
+      "lastUpdated": "2026-02-15",
+      "milestone": "docs-v1",
+      "priority": "low"
+    },
+    {
+      "id": "advanced-events",
+      "status": "in-progress",
+      "owner": "docs-team",
+      "lastUpdated": "2026-02-15",
+      "milestone": "docs-v2",
+      "priority": "medium"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- 공통 필드명을 고정해 `docs/data/` 하위의 메타데이터 파일들이 일관된 스키마를 따르도록 기준을 마련합니다. 
- 본 PR의 리뷰 포인트는 `데이터 스키마 적합성`으로 한정합니다. 
- 머지 후 다른 PR들은 이 문서의 스키마를 기준으로만 참조하도록 규칙을 명시합니다.

### Description

- `docs/data/schema.md`를 추가해 고정 필드명(`id`, `status`, `owner`, `lastUpdated`, `milestone`, `priority`)과 허용 값 목록 및 파일별 구조 예시를 문서화했습니다. 
- 샘플 데이터 파일로 `docs/data/components-status.json`, `docs/data/roadmap.json`, `docs/data/usage-guides.json`를 추가해 각 파일이 스키마에 부합하는 예시 레코드를 포함시켰습니다. 
- `docs/site/`, `.github/workflows/`, `README.md`, `package.json` 등은 변경하지 않았습니다.

### Testing

- `npm ci`를 실행해 의존성을 설치했고 성공했습니다. 
- `npm test`를 실행해 전체 테스트가 통과했으며 결과는 `2`개의 테스트 파일에서 `11`개의 테스트가 모두 성공했습니다. 
- `jq empty docs/data/components-status.json docs/data/roadmap.json docs/data/usage-guides.json`로 JSON 문법 검증을 수행했고 오류 없이 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913bea30d8832797b5b35f4b7e1ae2)