### PR TITLE
Add docs/site static pages with shared navigation shell

### DIFF
--- a/docs/site/assets/app.js
+++ b/docs/site/assets/app.js
@@ -1,0 +1,76 @@
+const TASK_A_JSON_PATH = './task-a.json';
+
+const NAV_ITEMS = [
+  { href: 'index.html', label: 'Overview', key: 'index' },
+  { href: 'components.html', label: 'Components', key: 'components' },
+  { href: 'roadmap.html', label: 'Roadmap', key: 'roadmap' },
+  { href: 'usage.html', label: 'Usage', key: 'usage' }
+];
+
+function mountShell() {
+  const pageKey = document.body.dataset.page ?? '';
+  const header = document.createElement('header');
+  header.className = 'site-header';
+
+  const navLinks = NAV_ITEMS.map(({ href, label, key }) => {
+    const current = key === pageKey ? ' aria-current="page"' : '';
+    return `<a href="${href}"${current}>${label}</a>`;
+  }).join('');
+
+  header.innerHTML = `
+    <div class="site-header__inner">
+      <h1 class="site-title">CE Docs Site</h1>
+      <nav class="site-nav" aria-label="Primary navigation">${navLinks}</nav>
+    </div>
+  `;
+
+  const main = document.querySelector('main');
+  const shell = document.createElement('div');
+  shell.className = 'site-shell';
+  if (main) {
+    main.parentNode?.insertBefore(header, main);
+    main.parentNode?.insertBefore(shell, main);
+    shell.appendChild(main);
+
+    const footer = document.createElement('footer');
+    footer.className = 'site-footer';
+    footer.innerHTML = `
+      <p>References: <a href="../api.md">docs/api.md</a> · <a href="../release.md">docs/release.md</a></p>
+      <p>Task A data source: <code>${TASK_A_JSON_PATH}</code></p>
+    `;
+    shell.appendChild(footer);
+  }
+}
+
+async function renderTaskAStatus() {
+  const targets = document.querySelectorAll('[data-task-a-status]');
+  if (!targets.length) {
+    return;
+  }
+
+  try {
+    const response = await fetch(TASK_A_JSON_PATH, { headers: { accept: 'application/json' } });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const keys = payload && typeof payload === 'object' ? Object.keys(payload) : [];
+    const message = keys.length
+      ? `Task A JSON loaded successfully (${keys.length} top-level keys).`
+      : 'Task A JSON loaded successfully.';
+
+    for (const el of targets) {
+      el.textContent = message;
+      el.classList.add('status--ok');
+    }
+  } catch (error) {
+    for (const el of targets) {
+      el.textContent = `Task A JSON is unavailable at ${TASK_A_JSON_PATH}. (${String(error)})`;
+      el.classList.add('status--error');
+    }
+  }
+}
+
+mountShell();
+void renderTaskAStatus();

--- a/docs/site/assets/styles.css
+++ b/docs/site/assets/styles.css
@@ -1,0 +1,108 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", Arial, sans-serif;
+  line-height: 1.5;
+  color: #1f2937;
+  background: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f8fafc;
+}
+
+.site-shell {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 0 1rem 2rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  background: rgba(248, 250, 252, 0.95);
+  backdrop-filter: blur(4px);
+  border-bottom: 1px solid #e5e7eb;
+  margin-bottom: 1.25rem;
+}
+
+.site-header__inner {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.site-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  color: #1f2937;
+  text-decoration: none;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.95rem;
+}
+
+.site-nav a[aria-current="page"] {
+  border-color: #2563eb;
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.card {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.card h2 {
+  margin-top: 0;
+}
+
+.status {
+  margin: 0.5rem 0 0;
+  color: #374151;
+  font-size: 0.95rem;
+}
+
+.status--error {
+  color: #b91c1c;
+}
+
+.status--ok {
+  color: #065f46;
+}
+
+.site-footer {
+  border-top: 1px solid #e5e7eb;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+ul,
+ol {
+  padding-left: 1.2rem;
+}

--- a/docs/site/components.html
+++ b/docs/site/components.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CE Docs Site | Components</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script defer src="assets/app.js"></script>
+  </head>
+  <body data-page="components">
+    <main>
+      <section class="card">
+        <h2>Components</h2>
+        <p>The runtime remains centered on <code>CE.define</code>, handlers, and isolated state updates.</p>
+        <p class="status" data-task-a-status>Checking Task A JSON availability…</p>
+      </section>
+      <section class="card">
+        <h2>Related Docs</h2>
+        <ol>
+          <li><a href="../api.md">API contract details</a></li>
+          <li><a href="../release.md">Release and rollback policy</a></li>
+        </ol>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CE Docs Site | Overview</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script defer src="assets/app.js"></script>
+  </head>
+  <body data-page="index">
+    <main>
+      <section class="card">
+        <h2>Overview</h2>
+        <p>This static docs site provides an entry point for CE usage, component boundaries, and release planning.</p>
+        <p class="status" data-task-a-status>Checking Task A JSON availability…</p>
+      </section>
+      <section class="card">
+        <h2>Core Documentation</h2>
+        <ul>
+          <li><a href="../api.md">API reference</a></li>
+          <li><a href="../release.md">Release process</a></li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/site/roadmap.html
+++ b/docs/site/roadmap.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CE Docs Site | Roadmap</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script defer src="assets/app.js"></script>
+  </head>
+  <body data-page="roadmap">
+    <main>
+      <section class="card">
+        <h2>Roadmap</h2>
+        <p>Current planning aligns feature work with compatibility requirements and release verification.</p>
+        <p class="status" data-task-a-status>Checking Task A JSON availability…</p>
+      </section>
+      <section class="card">
+        <h2>Planning Inputs</h2>
+        <ul>
+          <li><a href="../api.md">API constraints and semver</a></li>
+          <li><a href="../release.md">Release quality gates</a></li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/site/usage.html
+++ b/docs/site/usage.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CE Docs Site | Usage</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script defer src="assets/app.js"></script>
+  </head>
+  <body data-page="usage">
+    <main>
+      <section class="card">
+        <h2>Usage</h2>
+        <p>Use this section to connect implementation examples with the official API and release playbook.</p>
+        <p class="status" data-task-a-status>Checking Task A JSON availability…</p>
+      </section>
+      <section class="card">
+        <h2>Reference Links</h2>
+        <ul>
+          <li><a href="../api.md">Read docs/api.md</a></li>
+          <li><a href="../release.md">Read docs/release.md</a></li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a small static docs site under `docs/site/` to surface overview, components, roadmap and usage without changing root files or CI/README. 
- Keep scope minimal and avoid adding mock data by only referencing the Task A JSON path (`./task-a.json`) and linking to `docs/api.md` and `docs/release.md`.

### Description
- Add new pages: `docs/site/index.html`, `docs/site/components.html`, `docs/site/roadmap.html`, and `docs/site/usage.html` that use only local `docs/site` assets. 
- Add shared assets `docs/site/assets/styles.css` (layout/navigation styles) and `docs/site/assets/app.js` (injects common header/footer/navigation into pages and checks Task A JSON availability). 
- Implemented the common navigation/layout entirely inside `docs/site` so no other repository files are modified. 
- The site references only `./task-a.json` for Task A and only links to `docs/api.md` and `docs/release.md` as requested.

### Testing
- Ran `npm ci` successfully to install dependencies. 
- Ran `npm test` successfully; test run shows 2 test files and 11 tests passing (`tests/state-isolation.test.ts` and `test/ce.spec.ts`). 
- Served the site with `python3 -m http.server 4173` and captured a Playwright screenshot of `docs/site/index.html` to validate rendering and that the UI properly reports the `task-a.json` absence (fetch returns 404 and the page shows an error status).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913bea36d08327881241edd82459d0)