### PR TITLE
docs: document Pages ops metadata and status-board refresh checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ Detailed signatures and compatibility policy are documented in [`docs/api.md`](.
 
 ## Release flow
 Release/rollback/smoke-test checklist is documented in [`docs/release.md`](./docs/release.md).
+
+## Operations
+- Pages URL: https://ga-ut.github.io/ce/
+- Status data refresh cycle: Weekly (every Monday 10:00 KST) and immediately after release
+- Operational owner (status updates): Operations Team (release duty)
+
+### Status data update → validation → deployment (Ops quick procedure)
+1. Update the status dataset and changelog source used by the Pages site.
+2. Validate locally (`npm run lint`, `npm run test`, `npm run build`) and verify status board rendering.
+3. Deploy to Pages and confirm the published board reflects the latest status data.

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,6 +10,7 @@
 3. `npm run test`
 4. `npm run build`
 5. `npm run pack:check` (`npm pack --dry-run`)
+6. Confirm the document status board data was refreshed (or explicitly marked as no-change) for this release.
 
 ## Publish
 - Public package: `npm publish --access public`
@@ -26,6 +27,8 @@ Validate with sample app:
 - Route transitions
 - State updates
 - Event handling
+
+Also confirm the published Pages status board shows the latest status dataset timestamp.
 
 ## Rollback / safety
 - If issue is found, publish immediate patch (`x.y.(z+1)`) with fix.


### PR DESCRIPTION
### Motivation
- Centralize Pages operational metadata (Pages URL, refresh cadence, operational owner) and provide a short ops procedure so the status board stays current.
- Make the shared-docs update in one PR to minimize future rebase conflicts when multiple contributors change common files.

### Description
- Add an `Operations` section to `README.md` with the Pages URL `https://ga-ut.github.io/ce/`, weekly refresh cadence, the operational owner, and a 3-step `Status data update → validation → deployment` procedure.
- Add a pre-publish checklist item in `docs/release.md` to confirm the document status board data was refreshed (or marked no-change) and a post-release check to confirm the published Pages status board timestamp.
- Only `README.md` and `docs/release.md` were modified to keep the change scope minimal.

### Testing
- Ran `npm ci` to install dependencies and it completed successfully.
- Ran `npm run lint` which initially failed before `npm ci` due to missing type definitions and passed after `npm ci` completed.
- Ran `npm run test` and all tests passed (`2` test files, `11` tests passed).
- Ran `npm run build` and the ESM/CJS bundles and type declarations were generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913bec0f508327adbe6d4078d68e7d)