### PR TITLE
Fix stale route preload race and await async SSR render output

### DIFF
--- a/test/ce.spec.ts
+++ b/test/ce.spec.ts
@@ -198,6 +198,39 @@ describe("CE library", () => {
     expect(CE.entryElement?.firstElementChild?.tagName.toLowerCase()).toBe("x-fast-page");
   });
 
+  it("awaits hash navigation until async preload render completes", async () => {
+    CE.setEntryPoint("ce-hash-entry");
+
+    let resolvePreload = () => {};
+    const preloadPromise = new Promise<void>((resolve) => {
+      resolvePreload = resolve;
+    });
+
+    CE.define({
+      name: "x-hash-async-page",
+      state: {},
+      route: "/hash-async",
+      preload: () => preloadPromise,
+      render() {
+        return "<p>hash async</p>";
+      },
+    });
+
+    const navigation = CE.navigate("#/hash-async");
+    await wait();
+
+    expect(CE.entryElement?.firstElementChild?.tagName.toLowerCase()).not.toBe(
+      "x-hash-async-page"
+    );
+
+    resolvePreload();
+    await navigation;
+
+    expect(CE.entryElement?.firstElementChild?.tagName.toLowerCase()).toBe(
+      "x-hash-async-page"
+    );
+  });
+
   it("can render a route to string for server output", async () => {
     CE.define({
       name: "x-ssr-page",


### PR DESCRIPTION
### Motivation
- Prevent stale route updates where a slow earlier `preload` resolution overwrites a newer navigation.
- Ensure server-side rendering includes async `render()` results so SSR output matches client rendering.
- Add regression tests to guard against these timing-related regressions.

### Description
- Add a `renderToken` to `Router` and verify token/path consistency after `preload` settles to avoid applying stale navigation results or error fallbacks (changes in `src/ce.ts`).
- Make `CE.renderRouteToString` await the internal renderer and convert `renderComponentToString` to `async`, awaiting promised `render()` output before stringifying it (changes in `src/ce.ts`).
- Add two tests: one to verify stale `preload` completions do not overwrite the active route and one to verify async `render()` output is included in SSR markup (changes in `test/ce.spec.ts`).

### Testing
- Ran `npm run test` (Vitest) and all tests passed (13 tests across the suite).
- Ran `npm run lint` (TypeScript checks via `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913c4751a483278aa9b61a3185a78e)