### PR TITLE
Add preflight check for GitHub Pages enablement and incident log

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,6 +56,36 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Preflight - GitHub Pages 설정 점검
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            try {
+              const response = await github.rest.repos.getPages({ owner, repo });
+              const buildType = response.data?.build_type;
+
+              if (buildType !== 'workflow') {
+                core.setFailed(
+                  `GitHub Pages build_type is "${buildType}". Set Settings > Pages > Build and deployment > Source to "GitHub Actions".`
+                );
+                return;
+              }
+
+              core.info(`GitHub Pages is enabled (build_type=${buildType}).`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.setFailed(
+                  'GitHub Pages is not enabled for this repository. Enable it in Settings > Pages and set Source to "GitHub Actions".'
+                );
+                return;
+              }
+
+              throw error;
+            }
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
@@ -63,4 +93,5 @@ jobs:
       - name: 운영 가이드 (배포 실패 시)
         if: failure()
         run: |
-          echo "[운영 가이드] 배포 실패 시 docs/site, docs/data 경로 오설정 여부를 가장 먼저 점검하세요."
+          echo "[운영 가이드] 배포 실패 시 Settings > Pages 활성화 여부 및 Source=GitHub Actions 설정을 먼저 점검하세요."
+          echo "[운영 가이드] 다음으로 docs/site, docs/data 경로 오설정 여부를 점검하세요."

--- a/docs/operations/github-pages-deploy-incident-log.md
+++ b/docs/operations/github-pages-deploy-incident-log.md
@@ -1,0 +1,26 @@
+# GitHub Pages 배포 장애 기록
+
+## 발생 일시
+- 2026-02-15
+
+## 증상
+- `actions/deploy-pages@v4` 단계에서 `Creating Pages deployment failed`와 함께 `HttpError: Not Found (404)`가 발생.
+- 에러 메시지에 `Ensure GitHub Pages has been enabled`가 포함됨.
+
+## 원인 분석
+- 워크플로우는 `upload-pages-artifact`까지 정상 수행되어 artifact 생성에는 문제가 없음.
+- `deploy-pages` 단계의 404는 GitHub Pages 미활성화 상태이거나, Pages 소스가 `GitHub Actions`로 설정되지 않은 경우에 발생.
+- 즉, 경로(`docs/site`, `docs/data`) 문제가 아니라 리포지토리 Settings > Pages의 선행 설정 부재가 1차 원인.
+
+## 조치 내용
+1. `.github/workflows/pages.yml`의 `deploy` job 시작부에 **Preflight 점검 단계** 추가.
+   - GitHub API(`repos.getPages`)로 Pages 활성화 상태를 확인.
+   - Pages가 비활성화(404)면 즉시 실패 처리하고, 설정 위치와 필요한 값(Source=`GitHub Actions`)을 로그로 안내.
+   - Pages가 활성화되어도 `build_type != workflow`이면 즉시 실패 처리.
+2. 배포 실패 시 운영 가이드 로그를 보강.
+   - 기존의 경로 점검 안내에 더해, **Pages 활성화 및 Source 설정 점검**을 최우선으로 명시.
+
+## 기대 효과
+- 기존처럼 `deploy-pages` 단계에서 모호한 404를 뒤늦게 보는 대신,
+  설정 누락을 배포 전(preflight)에서 즉시 식별 가능.
+- 운영자가 확인해야 할 우선순위(설정 → 경로)가 명확해져 장애 대응 시간이 단축됨.


### PR DESCRIPTION
### Motivation
- Prevent unclear 404 failures from `actions/deploy-pages@v4` by detecting common repo misconfiguration (Pages disabled or Source not set to GitHub Actions) before attempting deployment.
- Make operational guidance explicit so responders check Pages settings first, then artifact paths.

### Description
- Added a Preflight step to `.github/workflows/pages.yml` (uses `actions/github-script@v7`) that calls `repos.getPages` and fails early if Pages is disabled (404) or `build_type !== 'workflow'`.
- Improved failure guidance messages in the workflow to prioritize `Settings > Pages` and `Source = GitHub Actions` checks before checking `docs/site`/`docs/data` paths.
- Added `docs/operations/github-pages-deploy-incident-log.md` documenting the observed 404 symptom, root cause analysis, remediation, and expected effect.
- Scope of changes is limited to the Pages workflow and operational documentation only.

### Testing
- Validated workflow syntax by loading `.github/workflows/pages.yml` with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pages.yml')"`, which completed successfully.
- Inspected the updated workflow file to ensure the preflight step and guidance messages are present and correctly formatted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918fb8f49c832797e9f32378826061)