### PR TITLE
Fix Pages artifact packaging so /ce/ serves index.html

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare Pages artifact (docs/site + docs/data)
+      - name: Prepare Pages artifact (docs/site/* + docs/data)
         run: |
           set -euo pipefail
           mkdir -p _pages_artifact
 
           if [[ -d docs/site ]]; then
-            cp -a docs/site _pages_artifact/site
+            cp -a docs/site/. _pages_artifact/
           else
             echo "docs/site not found; skipping copy"
           fi


### PR DESCRIPTION
### Motivation
- The published site root `https://ga-ut.github.io/ce/` returned 404 because the Pages workflow uploaded `docs/site` nested under `/site`, so the real entrypoint lived at `/site/index.html` instead of the artifact root.

### Description
- Updated `.github/workflows/pages.yml` to copy `docs/site` contents into the artifact root with `cp -a docs/site/. _pages_artifact/` instead of `cp -a docs/site _pages_artifact/site`.
- Left `docs/data` packaging unchanged as `_pages_artifact/data` and kept the remainder of the workflow logic intact.

### Testing
- Simulated the new artifact layout with `cp -a docs/site/. "$dir"/; cp -a docs/data "$dir"/data; find ...` and confirmed `index.html` appears at the artifact root (succeeded).
- Validated workflow YAML syntax with `ruby -e "require 'yaml'; ..."` to ensure parsing succeeded (succeeded).
- Attempted `actionlint .github/workflows/pages.yml` (failed because `actionlint` is not installed) and attempted Python `pyyaml` parse (failed because `pyyaml` is not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992c58dc96083278515ecc7246bd4ca)