### PR TITLE
feat(ci): add Codex task workflows

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -1,0 +1,23 @@
+name: close-issue
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  close:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          NUM=$(printf '%s\n' "$PR_BODY" | sed -n 's/^<!-- SOURCE_ISSUE_ID=\([0-9][0-9]*\) -->$/\1/p' | head -n 1)
+          if [[ -n "$NUM" ]]; then
+            gh issue close "$NUM"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/handle-result.yml
+++ b/.github/workflows/handle-result.yml
@@ -1,0 +1,45 @@
+name: handle-codex-result
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  process:
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "$COMMENT_AUTHOR" != "$CODEX_LOGIN" ]]; then
+            exit 0
+          fi
+
+          BODY="$COMMENT_BODY"
+          PR=${{ github.event.issue.number }}
+          ISSUE_NUMBER=$(gh pr view "$PR" --json body --jq '.body' | sed -n 's/^<!-- SOURCE_ISSUE_ID=\([0-9][0-9]*\) -->$/\1/p' | head -n 1)
+          TOKEN=$(printf '%s\n' "$BODY" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+          if [[ "$TOKEN" == "TASK_INVALID" ]]; then
+            gh pr close "$PR"
+            if [[ -n "$ISSUE_NUMBER" ]]; then
+              gh issue close "$ISSUE_NUMBER"
+            fi
+          elif [[ "$TOKEN" == "TASK_DONE" ]]; then
+            {
+              printf '%s\n' '@codex verify this PR.' ''
+              printf '%s\n' 'If correct:' '- REVIEW_OK' '- merge this PR' '- delete branch' ''
+              printf '%s\n' 'If not:' '- explain issues'
+            } > verify-comment.txt
+
+            gh pr ready "$PR"
+            gh pr comment "$PR" --body-file verify-comment.txt
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          CODEX_LOGIN: ${{ vars.CODEX_LOGIN || 'openai-codex[bot]' }}

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -1,0 +1,39 @@
+name: issue-to-draft-pr
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: |
+          BRANCH=task-${{ github.event.issue.number }}
+          git checkout -b "$BRANCH"
+          git push origin HEAD:refs/heads/"$BRANCH"
+
+      - run: |
+          {
+            printf '<!-- SOURCE_ISSUE_ID=%s -->\n' "${{ github.event.issue.number }}"
+            printf '%s\n' '@codex' '' 'Execute this task:' ''
+            printf '%s\n' "$ISSUE_BODY" ''
+            printf '%s\n' 'Rules:' '- valid -> implement' '- invalid -> TASK_INVALID' '- uncertain -> TASK_FAILED' ''
+            printf '%s\n' 'After:' '- TASK_DONE / TASK_INVALID / TASK_FAILED' ''
+          } > pr-body.txt
+
+          gh pr create \
+            --title "Task #${{ github.event.issue.number }}" \
+            --body-file pr-body.txt \
+            --draft \
+            --base main \
+            --head task-${{ github.event.issue.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -1,0 +1,22 @@
+name: scheduler
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+permissions:
+  issues: write
+
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh issue create \
+            --title "[TASK] periodic review" \
+            --body '{
+              "goal": "Analyze repo and suggest improvements",
+              "acceptance": ["no regressions", "tests pass"]
+            }'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Overview
Add four GitHub Actions workflows to run an issue -> draft PR -> Codex result -> Codex verify -> Codex merge -> issue close loop.

## Why
The repository needs a GitHub-native automation loop that creates work from issues, keeps Codex execution in PR context, and lets Codex own verification and merge.

## What Changed
- add an hourly scheduler workflow that opens a task issue
- add an issue-to-draft-PR workflow with Codex task instructions in the PR body
- add a Codex-result handler that reacts to exact tokens from the configured Codex bot login
- add a merged-PR closer that closes the originating issue by canonical PR-body marker

## Impact
- no breaking changes expected
- no runtime package behavior changes
- no database or release artifact changes
- requires Codex GitHub integration and, if needed, `CODEX_LOGIN` repository variable configuration

## How to Test
- Run `ruby -e 'require "yaml"; Dir[".github/workflows/{scheduler,issue-to-pr,handle-result,close-issue}.yml"].each { |f| YAML.load_file(f); puts "OK #{f}" }'`
- Confirm exact token and command strings exist in the new workflow files.
- Merge to `main`, wait for the hourly scheduler or open a test issue manually, and verify the issue -> draft PR flow.
- Post exact Codex-token comments from the configured Codex bot path and verify the TASK_DONE / TASK_INVALID branches.

## Related Issues
N/A
