### PR TITLE
fix(ci): harden automation workflows

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -16,8 +16,9 @@ jobs:
       - run: |
           NUM=$(printf '%s\n' "$PR_BODY" | sed -n 's/^<!-- SOURCE_ISSUE_ID=\([0-9][0-9]*\) -->$/\1/p' | head -n 1)
           if [[ -n "$NUM" ]]; then
-            gh issue close "$NUM"
+            gh issue close "$NUM" --repo "$GH_REPO"
           fi
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/handle-result.yml
+++ b/.github/workflows/handle-result.yml
@@ -20,14 +20,17 @@ jobs:
 
           BODY="$COMMENT_BODY"
           PR=${{ github.event.issue.number }}
-          ISSUE_NUMBER=$(gh pr view "$PR" --json body --jq '.body' | sed -n 's/^<!-- SOURCE_ISSUE_ID=\([0-9][0-9]*\) -->$/\1/p' | head -n 1)
+          ISSUE_NUMBER=$(gh pr view "$PR" --repo "$GH_REPO" --json body --jq '.body' | sed -n 's/^<!-- SOURCE_ISSUE_ID=\([0-9][0-9]*\) -->$/\1/p' | head -n 1)
           TOKEN=$(printf '%s\n' "$BODY" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 
           if [[ "$TOKEN" == "TASK_INVALID" ]]; then
-            gh pr close "$PR"
+            gh pr close "$PR" --repo "$GH_REPO"
             if [[ -n "$ISSUE_NUMBER" ]]; then
-              gh issue close "$ISSUE_NUMBER"
+              gh issue close "$ISSUE_NUMBER" --repo "$GH_REPO"
             fi
+          elif [[ "$TOKEN" == "TASK_FAILED" ]]; then
+            gh pr comment "$PR" --repo "$GH_REPO" --body "Codex reported TASK_FAILED. Leaving the linked issue open for manual follow-up."
+            gh pr close "$PR" --repo "$GH_REPO"
           elif [[ "$TOKEN" == "TASK_DONE" ]]; then
             {
               printf '%s\n' '@codex verify this PR.' ''
@@ -35,10 +38,11 @@ jobs:
               printf '%s\n' 'If not:' '- explain issues'
             } > verify-comment.txt
 
-            gh pr ready "$PR"
-            gh pr comment "$PR" --body-file verify-comment.txt
+            gh pr ready "$PR" --repo "$GH_REPO"
+            gh pr comment "$PR" --repo "$GH_REPO" --body-file verify-comment.txt
           fi
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -3,25 +3,68 @@ name: issue-to-draft-pr
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to convert into a draft PR
+        required: true
+        type: string
 
 permissions:
+  actions: write
   contents: write
+  issues: read
   pull-requests: write
 
 jobs:
   create-pr:
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.issue.title, '[TASK]') && github.event.issue.user.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - run: |
-          BRANCH=task-${{ github.event.issue.number }}
-          git checkout -b "$BRANCH"
+          ISSUE_NUMBER="${INPUT_ISSUE_NUMBER:-$EVENT_ISSUE_NUMBER}"
+          BASE_BRANCH=$(gh repo view --repo "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')
+          BRANCH="task-$ISSUE_NUMBER"
+
+          if [[ "$(gh pr list --repo "$GH_REPO" --head "$BRANCH" --json number --jq 'length')" != "0" ]]; then
+            echo "PR already exists for $BRANCH; skipping."
+            exit 0
+          fi
+
+          git fetch origin "$BASE_BRANCH"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git push origin :refs/heads/"$BRANCH"
+          fi
+          git checkout -B "$BRANCH" "origin/$BASE_BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "chore(task): bootstrap issue $ISSUE_NUMBER"
           git push origin HEAD:refs/heads/"$BRANCH"
+        env:
+          EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
 
       - run: |
+          ISSUE_NUMBER="${INPUT_ISSUE_NUMBER:-$EVENT_ISSUE_NUMBER}"
+          ISSUE_BODY="$EVENT_ISSUE_BODY"
+          BRANCH="task-$ISSUE_NUMBER"
+          BASE_BRANCH=$(gh repo view --repo "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')
+
+          if [[ "$(gh pr list --repo "$GH_REPO" --head "$BRANCH" --json number --jq 'length')" != "0" ]]; then
+            echo "PR already exists for $BRANCH; skipping."
+            exit 0
+          fi
+
+          if [[ -z "$ISSUE_BODY" ]]; then
+            ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$GH_REPO" --json body --jq '.body')
+          fi
+
           {
-            printf '<!-- SOURCE_ISSUE_ID=%s -->\n' "${{ github.event.issue.number }}"
+            printf '<!-- SOURCE_ISSUE_ID=%s -->\n' "$ISSUE_NUMBER"
             printf '%s\n' '@codex' '' 'Execute this task:' ''
             printf '%s\n' "$ISSUE_BODY" ''
             printf '%s\n' 'Rules:' '- valid -> implement' '- invalid -> TASK_INVALID' '- uncertain -> TASK_FAILED' ''
@@ -29,11 +72,19 @@ jobs:
           } > pr-body.txt
 
           gh pr create \
-            --title "Task #${{ github.event.issue.number }}" \
+            --repo "$GH_REPO" \
+            --title "Task #$ISSUE_NUMBER" \
             --body-file pr-body.txt \
             --draft \
-            --base main \
-            --head task-${{ github.event.issue.number }}
+            --base "$BASE_BRANCH" \
+            --head "$BRANCH"
+
+          gh workflow run release-check.yml \
+            --repo "$GH_REPO" \
+            --ref "$BRANCH"
         env:
+          EVENT_ISSUE_BODY: ${{ github.event.issue.body }}
+          EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,25 +11,45 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
-          cache: npm
+
+      - name: Validate publish ref
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION=$(node -p "require('./packages/ce/package.json').version")
+
+          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Publishing requires a v<semver> tag ref. Got: $GITHUB_REF"
+            exit 1
+          fi
+
+          if [[ "v$PACKAGE_VERSION" != "$GITHUB_REF_NAME" ]]; then
+            echo "Tag $GITHUB_REF_NAME does not match package version v$PACKAGE_VERSION"
+            exit 1
+          fi
 
       - name: Install dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
 
       - name: Validate and build
-        run: npm run lint && npm test && npm run build
+        run: bun run verify:full
 
       - name: Publish package
         run: npm publish --access public
+        working-directory: packages/ce
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,17 +22,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
 
-      - name: Build package for playground runtime
-        run: npm run build
+      - name: Validate and build Pages inputs
+        run: bun run verify:full
 
       - name: Prepare Pages artifact (docs/site/* + docs/data + dist)
         run: |

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -5,17 +5,18 @@ on:
     tags:
       - 'v*.*.*'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run test
-      - run: npm run build
+      - run: bun install --frozen-lockfile
+      - run: bun run verify:full

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -5,6 +5,7 @@ on:
     - cron: "0 * * * *"
 
 permissions:
+  actions: write
   issues: write
 
 jobs:
@@ -12,11 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          gh issue create \
+          ISSUE_URL=$(gh issue create \
+            --repo "$GH_REPO" \
             --title "[TASK] periodic review" \
             --body '{
               "goal": "Analyze repo and suggest improvements",
               "acceptance": ["no regressions", "tests pass"]
-            }'
+            }')
+          ISSUE_NUMBER="${ISSUE_URL##*/}"
+
+          gh workflow run issue-to-pr.yml \
+            --repo "$GH_REPO" \
+            --ref "$GH_REF" \
+            -f issue_number="$ISSUE_NUMBER"
         env:
+          GH_REF: ${{ github.ref_name }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Overview
Harden the repository's GitHub Actions automation chain and align CI validation with the repository's stronger workflow policy.

## Why
The scheduled task flow had a confirmed `gh` repository-resolution failure and broader workflow-logic risks around implicit workflow fan-out, missing terminal-state handling, and validation gaps between PR, Pages, and publish paths.

## What Changed
- switch the scheduler to create the issue and explicitly dispatch the PR-bootstrap workflow
- restrict task PR bootstrap to intended task issues, add stale-branch cleanup, and seed a deterministic bootstrap commit before PR creation
- add explicit `--repo` targeting to no-checkout `gh` calls and define `TASK_FAILED` handling
- upgrade release, Pages, and publish validation to the stronger `verify:full` path
- add Node 20 setup to PR/Pages validation and gate publish on a matching `v<semver>` tag

## Impact
- no breaking package API changes
- CI becomes stricter and may fail changes that previously slipped past event/docs/pack validation
- publish is now blocked unless the ref is a semver tag matching `packages/ce/package.json`
- scheduler still creates a new periodic task every hour; that remains operational noise rather than a correctness blocker

## How to Test
Run `npm run verify:full`.
Confirm the workflow files parse cleanly.
Optionally exercise one scheduled task run and one tag-driven publish dry run in GitHub Actions.

## Related Issues
None.
