### PR TITLE
fix(ci): limit pages deploy paths

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/pages.yml
+      - .bun-version
+      - bun.lock
+      - package.json
+      - tsconfig.json
+      - tsconfig.base.json
+      - docs/site/**
+      - docs/data/**
+      - apps/playground/**
+      - packages/ce/src/**
+      - packages/ce/tsconfig.json
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Overview
GitHub Pages 배포 워크플로우가 관련 파일이 바뀐 경우에만 실행되도록 `paths` 필터를 추가했습니다.

## Why
기존 `pages.yml`은 `main`에 push가 발생하면 변경 범위와 관계없이 항상 실행됐습니다. 문서 사이트나 playground, CE 빌드 산출물과 무관한 변경에도 배포가 돌아 불필요한 CI 시간을 사용했습니다.

## What Changed
- `.github/workflows/pages.yml`의 `push` 트리거에 `paths` 필터를 추가했습니다.
- Pages 배포와 직접 관련된 workflow, lockfile, tsconfig, docs/site, docs/data, playground, `packages/ce/src` 변경만 배포를 트리거하도록 제한했습니다.
- `workflow_dispatch` 수동 실행 경로는 그대로 유지했습니다.

## Impact
- breaking changes: 없음
- performance: 불필요한 Pages 배포 감소
- security: 없음
- database migrations: 없음

## How to Test
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pages.yml"); puts "ok"'`
- 관련 경로 변경이 있는 커밋에서는 Pages workflow가 실행되고, 무관한 변경에서는 실행되지 않는지 확인

## Related Issues
Closes #none
