### PR TITLE
Remove cron trigger from scheduler workflow

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -1,8 +1,6 @@
 name: scheduler
 
 on:
-  schedule:
-    - cron: "0 * * * *"
   workflow_dispatch:
     inputs:
       task_key:


### PR DESCRIPTION
### Motivation
- Stop automatic periodic execution of the scheduler workflow so scheduled tasks no longer run hourly while preserving the ability to run the job manually.

### Description
- Removed the `schedule` (cron) trigger from `.github/workflows/scheduler.yml` and kept the `workflow_dispatch` input-based manual trigger intact.

### Testing
- Ran `npm run lint`, which failed due to an existing TypeScript deprecation error in `apps/playground/tsconfig.json` (TS5101) that is unrelated to this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04869dadbc8327a88c64879698caef)