### PR TITLE
fix: add GA-UT UI favicon

### DIFF
--- a/apps/ui-showcase/index.html
+++ b/apps/ui-showcase/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzNiAzNiIgZmlsbD0ibm9uZSI+CiAgPHBhdGgKICAgIGQ9Ik0xOCAyLjc1IDMyLjI1IDkuOXYxMy4zNUwxOCAzMy4yNSAzLjc1IDIzLjI1VjkuOVoiCiAgICBzdHJva2U9IiNFODREM0QiCiAgICBzdHJva2Utd2lkdGg9IjIuNCIKICAgIHN0cm9rZS1saW5lam9pbj0ibWl0ZXIiCiAgLz4KICA8cGF0aAogICAgZD0iTTEwLjI1IDEyLjc1djguMWMwIDQuNjUgMy4zNSA3LjE1IDcuNzUgNy4xNXM3Ljc1LTIuNSA3Ljc1LTcuMTV2LTguMSIKICAgIHN0cm9rZT0iI0U4NEQzRCIKICAgIHN0cm9rZS13aWR0aD0iMi4xNSIKICAvPgogIDxwYXRoCiAgICBkPSJNMTIuNzUgMTIuMjVoMTAuNU0xOCAxMi4yNXYxMC41IgogICAgc3Ryb2tlPSIjRTg0RDNEIgogICAgc3Ryb2tlLXdpZHRoPSIyLjYiCiAgLz4KPC9zdmc+Cg=="
+    />
     <meta
       name="description"
       content="GA-UT UI — CE 위에 세운 GA-UT의 제품 인터페이스 시스템"


### PR DESCRIPTION
## Summary
- embed the GA-UT mark as the UI showcase favicon
- remove the live Pages favicon.ico 404 without adding another deployment asset

## Validation
- bun run lint
- bun run build
- live issue reproduced on https://ga-ut.github.io/ce/ui/